### PR TITLE
Speed up ssh-keyparse public generator code by 10x

### DIFF
--- a/ssh-keyparse
+++ b/ssh-keyparse
@@ -158,112 +158,249 @@ def _ssh_key_parse(path, tmp, patch_sk=None):
 
 
 def ed25519_pubkey_from_seed(sk):
-	# Crypto code here is verbatim from http://ed25519.cr.yp.to/python/ed25519.py
+	# Crypto code here is verbatim from https://github.com/pyca/ed25519/blob/master/ed25519.py
+	
+	# Useful for very coarse version differentiation.
+	PY3 = sys.version_info[0] == 3
+
+	if PY3:
+		indexbytes = operator.getitem
+		intlist2bytes = bytes
+		int2byte = operator.methodcaller("to_bytes", 1, "big")
+	else:
+		int2byte = chr
+		range = xrange
+
+		def indexbytes(buf, i):
+			return ord(buf[i])
+
+		def intlist2bytes(l):
+			return b"".join(chr(c) for c in l)
 
 	b = 256
-	q = 2**255 - 19
-	l = 2**252 + 27742317777372353535851937790883648493
+	q = 2 ** 255 - 19
+	l = 2 ** 252 + 27742317777372353535851937790883648493
 
 	def H(m):
 		return hashlib.sha512(m).digest()
 
-	def expmod(b,e,m):
-		if e == 0: return 1
-		t = expmod(b,e/2,m)**2 % m
-		if e & 1: t = (t*b) % m
-		return t
+	def pow2(x, p):
+		"""== pow(x, 2**p, q)"""
+		while p > 0:
+			x = x * x % q
+			p -= 1
+		return x
 
-	def inv(x):
-		return expmod(x,q-2,q)
+	def inv(z):
+		"""$= z^{-1} \mod q$, for z != 0"""
+		# Adapted from curve25519_athlon.c in djb's Curve25519.
+		z2 = z * z % q  # 2
+		z9 = pow2(z2, 2) * z % q  # 9
+		z11 = z9 * z2 % q  # 11
+		z2_5_0 = (z11 * z11) % q * z9 % q  # 31 == 2^5 - 2^0
+		z2_10_0 = pow2(z2_5_0, 5) * z2_5_0 % q  # 2^10 - 2^0
+		z2_20_0 = pow2(z2_10_0, 10) * z2_10_0 % q  # ...
+		z2_40_0 = pow2(z2_20_0, 20) * z2_20_0 % q
+		z2_50_0 = pow2(z2_40_0, 10) * z2_10_0 % q
+		z2_100_0 = pow2(z2_50_0, 50) * z2_50_0 % q
+		z2_200_0 = pow2(z2_100_0, 100) * z2_100_0 % q
+		z2_250_0 = pow2(z2_200_0, 50) * z2_50_0 % q  # 2^250 - 2^0
+		return pow2(z2_250_0, 5) * z11 % q  # 2^255 - 2^5 + 11 = q - 2
 
-	d = -121665 * inv(121666)
-	I = expmod(2,(q-1)/4,q)
+	d = -121665 * inv(121666) % q
+	I = pow(2, (q - 1) // 4, q)
 
 	def xrecover(y):
-		xx = (y*y-1) * inv(d*y*y+1)
-		x = expmod(xx,(q+3)/8,q)
-		if (x*x - xx) % q != 0: x = (x*I) % q
-		if x % 2 != 0: x = q-x
+		xx = (y * y - 1) * inv(d * y * y + 1)
+		x = pow(xx, (q + 3) // 8, q)
+
+		if (x * x - xx) % q != 0:
+			x = (x * I) % q
+
+		if x % 2 != 0:
+			x = q - x
+
 		return x
 
 	By = 4 * inv(5)
 	Bx = xrecover(By)
-	B = [Bx % q,By % q]
+	B = (Bx % q, By % q, 1, (Bx * By) % q)
+	ident = (0, 1, 1, 0)
 
-	def edwards(P,Q):
-		x1 = P[0]
-		y1 = P[1]
-		x2 = Q[0]
-		y2 = Q[1]
-		x3 = (x1*y2+x2*y1) * inv(1+d*x1*x2*y1*y2)
-		y3 = (y1*y2+x1*x2) * inv(1-d*x1*x2*y1*y2)
-		return [x3 % q,y3 % q]
+	def edwards_add(P, Q):
+		# This is formula sequence 'addition-add-2008-hwcd-3' from
+		# http://www.hyperelliptic.org/EFD/g1p/auto-twisted-extended-1.html
+		(x1, y1, z1, t1) = P
+		(x2, y2, z2, t2) = Q
 
-	def scalarmult(P,e):
-		if e == 0: return [0,1]
-		Q = scalarmult(P,e/2)
-		Q = edwards(Q,Q)
-		if e & 1: Q = edwards(Q,P)
+		a = (y1 - x1) * (y2 - x2) % q
+		b = (y1 + x1) * (y2 + x2) % q
+		c = t1 * 2 * d * t2 % q
+		dd = z1 * 2 * z2 % q
+		e = b - a
+		f = dd - c
+		g = dd + c
+		h = b + a
+		x3 = e * f
+		y3 = g * h
+		t3 = e * h
+		z3 = f * g
+
+		return (x3 % q, y3 % q, z3 % q, t3 % q)
+
+	def edwards_double(P):
+		# This is formula sequence 'dbl-2008-hwcd' from
+		# http://www.hyperelliptic.org/EFD/g1p/auto-twisted-extended-1.html
+		(x1, y1, z1, t1) = P
+
+		a = x1 * x1 % q
+		b = y1 * y1 % q
+		c = 2 * z1 * z1 % q
+		# dd = -a
+		e = ((x1 + y1) * (x1 + y1) - a - b) % q
+		g = -a + b  # dd + b
+		f = g - c
+		h = -a - b  # dd - b
+		x3 = e * f
+		y3 = g * h
+		t3 = e * h
+		z3 = f * g
+
+		return (x3 % q, y3 % q, z3 % q, t3 % q)
+
+	def scalarmult(P, e):
+		if e == 0:
+			return ident
+		Q = scalarmult(P, e // 2)
+		Q = edwards_double(Q)
+		if e & 1:
+			Q = edwards_add(Q, P)
 		return Q
+
+	# Bpow[i] == scalarmult(B, 2**i)
+	Bpow = []
+
+	def make_Bpow():
+		P = B
+		for i in range(253):
+			Bpow.append(P)
+			P = edwards_double(P)
+
+	make_Bpow()
+
+	def scalarmult_B(e):
+		"""
+        Implements scalarmult(B, e) more efficiently.
+        """
+		# scalarmult(B, l) is the identity
+		e = e % l
+		P = ident
+		for i in range(253):
+			if e & 1:
+				P = edwards_add(P, Bpow[i])
+			e = e // 2
+		assert e == 0, e
+		return P
 
 	def encodeint(y):
 		bits = [(y >> i) & 1 for i in range(b)]
-		return ''.join([chr(sum([bits[i * 8 + j] << j for j in range(8)])) for i in range(b/8)])
+		return b''.join([
+			int2byte(sum([bits[i * 8 + j] << j for j in range(8)]))
+			for i in range(b // 8)
+		])
 
 	def encodepoint(P):
-		x = P[0]
-		y = P[1]
+		(x, y, z, t) = P
+		zi = inv(z)
+		x = (x * zi) % q
+		y = (y * zi) % q
 		bits = [(y >> i) & 1 for i in range(b - 1)] + [x & 1]
-		return ''.join([chr(sum([bits[i * 8 + j] << j for j in range(8)])) for i in range(b/8)])
+		return b''.join([
+			int2byte(sum([bits[i * 8 + j] << j for j in range(8)]))
+			for i in range(b // 8)
+		])
 
-	def bit(h,i):
-		return (ord(h[i/8]) >> (i%8)) & 1
+	def bit(h, i):
+		return (indexbytes(h, i // 8) >> (i % 8)) & 1
 
-	def publickey(sk):
+	def publickey_unsafe(sk):
+		"""
+        Not safe to use with secret keys or secret data.
+
+        See module docstring.  This function should be used for testing only.
+        """
 		h = H(sk)
-		a = 2**(b-2) + sum(2**i * bit(h,i) for i in range(3,b-2))
-		A = scalarmult(B,a)
+		a = 2 ** (b - 2) + sum(2 ** i * bit(h, i) for i in range(3, b - 2))
+		A = scalarmult_B(a)
 		return encodepoint(A)
 
 	def Hint(m):
 		h = H(m)
-		return sum(2**i * bit(h,i) for i in range(2*b))
+		return sum(2 ** i * bit(h, i) for i in range(2 * b))
 
-	def signature(m,sk,pk):
+	def signature_unsafe(m, sk, pk):
+		"""
+        Not safe to use with secret keys or secret data.
+
+        See module docstring.  This function should be used for testing only.
+        """
 		h = H(sk)
-		a = 2**(b-2) + sum(2**i * bit(h,i) for i in range(3,b-2))
-		r = Hint(''.join([h[i] for i in range(b/8,b/4)]) + m)
-		R = scalarmult(B,r)
+		a = 2 ** (b - 2) + sum(2 ** i * bit(h, i) for i in range(3, b - 2))
+		r = Hint(
+			intlist2bytes([indexbytes(h, j) for j in range(b // 8, b // 4)]) + m
+		)
+		R = scalarmult_B(r)
 		S = (r + Hint(encodepoint(R) + pk + m) * a) % l
 		return encodepoint(R) + encodeint(S)
 
 	def isoncurve(P):
-		x = P[0]
-		y = P[1]
-		return (-x*x + y*y - 1 - d*x*x*y*y) % q == 0
+		(x, y, z, t) = P
+		return (z % q != 0 and
+				x * y % q == z * t % q and
+				(y * y - x * x - z * z - d * t * t) % q == 0)
 
 	def decodeint(s):
-		return sum(2**i * bit(s,i) for i in range(0,b))
+		return sum(2 ** i * bit(s, i) for i in range(0, b))
 
 	def decodepoint(s):
-		y = sum(2**i * bit(s,i) for i in range(0,b-1))
+		y = sum(2 ** i * bit(s, i) for i in range(0, b - 1))
 		x = xrecover(y)
-		if x & 1 != bit(s,b-1): x = q-x
-		P = [x,y]
-		if not isoncurve(P): raise Exception("decoding point that is not on curve")
+		if x & 1 != bit(s, b - 1):
+			x = q - x
+		P = (x, y, 1, (x * y) % q)
+		if not isoncurve(P):
+			raise ValueError("decoding point that is not on curve")
 		return P
 
-	def checkvalid(s,m,pk):
-		if len(s) != b/4: raise Exception("signature length is wrong")
-		if len(pk) != b/8: raise Exception("public-key length is wrong")
-		R = decodepoint(s[0:b/8])
-		A = decodepoint(pk)
-		S = decodeint(s[b/8:b/4])
-		h = Hint(encodepoint(R) + pk + m)
-		if scalarmult(B,S) != edwards(R,scalarmult(A,h)):
-			raise Exception("signature does not pass verification")
+	class SignatureMismatch(Exception):
+		pass
 
-	pk = publickey(sk)
+	def checkvalid(s, m, pk):
+		"""
+        Not safe to use when any argument is secret.
+
+        See module docstring.  This function should be used only for
+        verifying public signatures of public messages.
+        """
+		if len(s) != b // 4:
+			raise ValueError("signature length is wrong")
+
+		if len(pk) != b // 8:
+			raise ValueError("public-key length is wrong")
+
+		R = decodepoint(s[:b // 8])
+		A = decodepoint(pk)
+		S = decodeint(s[b // 8:b // 4])
+		h = Hint(encodepoint(R) + pk + m)
+
+		(x1, y1, z1, t1) = P = scalarmult_B(S)
+		(x2, y2, z2, t2) = Q = edwards_add(R, scalarmult(A, h))
+
+		if (not isoncurve(P) or not isoncurve(Q) or
+						(x1 * z2 - x2 * z1) % q != 0 or (y1 * z2 - y2 * z1) % q != 0):
+			raise SignatureMismatch("signature does not pass verification")
+
+	pk = publickey_unsafe(sk)
 	# m = 'test'
 	# s = signature(m, sk, pk)
 	# checkvalid(s, m, pk)


### PR DESCRIPTION
I have found some code that speeds up the seed to public key calculation by roughly 10 times.

Solves #10 

(merge is not strictly required since the new code has some 'unsafe' warnings in its source, but if people look for something faster with no regard for security, this pull might be useful for them to know about)

```
time python ssh-keyparse.py  --expand-seed HOSEWmGJtkrOBOuTGGOFXsMIsMqlnQTWAGcRIWXvRqQ=
HOSEWmGJtkrOBOuTGGOFXsMIsMqlnQTWAGcRIWXvRqTaKUyc_3dnDL-FS4_32JFsF88oQoYb2lU0QYtLgOx-yA==

real	0m0.154s
user	0m0.066s
sys	0m0.070s
```
▲ new | old  ▼

```
time python ssh-keyparse.py  --expand-seed HOSEWmGJtkrOBOuTGGOFXsMIsMqlnQTWAGcRIWXvRqQ=
HOSEWmGJtkrOBOuTGGOFXsMIsMqlnQTWAGcRIWXvRqTaKUyc_3dnDL-FS4_32JFsF88oQoYb2lU0QYtLgOx-yA==

real	0m1.385s
user	0m1.317s
sys	0m0.048s

```